### PR TITLE
Add inversion function in GF(2^n) for sage.crypto.sboxes

### DIFF
--- a/src/sage/crypto/sboxes.py
+++ b/src/sage/crypto/sboxes.py
@@ -399,6 +399,27 @@ def monomial_function(n, e):
     return SBox(X**e)
 
 
+def inversion(n):
+    r"""
+    Return the S-Box constructed from the inversion mapping over `\GF{2^n}` extending `0 \mapsto 0`
+
+    INPUT:
+
+    - ``n`` -- size of the S-Box (i.e. the degree of the finite field extension)
+
+    EXAMPLES::
+
+        sage: from sage.crypto.sboxes import inversion
+        sage: S4 = inversion(4)
+        sage: S4.differential_uniformity()
+        4
+        sage: S5 = inversion(5)
+        sage: S5.differential_uniformity()
+        2
+    """
+    return monomial_function(n, 2**n - 2)
+
+
 # Bijective S-Boxes mapping 9 bits to 9
 # =====================================
 


### PR DESCRIPTION
Add inversion mapping in GF(2^n) extending 0 -> 0. Such mapping is used for instance in the AES S-Box.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

